### PR TITLE
Get the reserve ratio from the contract

### DIFF
--- a/lib/abi/market-maker.json
+++ b/lib/abi/market-maker.json
@@ -1,0 +1,33 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_collateral",
+        "type": "address"
+      }
+    ],
+    "name": "getCollateralToken",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/lib/known-contracts.js
+++ b/lib/known-contracts.js
@@ -4,6 +4,7 @@ import tokenAbi from './abi/token.json'
 import tokenManagerAbi from './abi/token-manager.json'
 import bancorAbi from './abi/bancor.json'
 import marketplaceAbi from './abi/marketplace.json'
+import marketMakerAbi from './abi/market-maker.json'
 
 import { knownContracts } from '../config'
 
@@ -15,6 +16,7 @@ const ABIS = new Map([
   ['TOKEN_MANAGER', tokenManagerAbi],
   ['BANCOR_FORMULA', bancorAbi],
   ['MARKETPLACE', marketplaceAbi],
+  ['MARKET_MAKER', marketMakerAbi],
 ])
 
 export function getKnownAbi(name) {

--- a/lib/web3-contracts.js
+++ b/lib/web3-contracts.js
@@ -1,35 +1,16 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { Contract as EthersContract, utils as EthersUtils } from 'ethers'
-import environment from 'lib/environment'
 import { getKnownContract, getKnownAbi } from './known-contracts'
 import { useWalletAugmented } from './wallet'
 import { bigNum } from './utils'
 
 import { collateral, bonded } from '../config'
 
-// See https://fundraising.aragon.black/components/bonding-curve#pricing-algorithm
-const MAINNET_CONNECTOR_WEIGHT = 250000
-const RINKEBY_CONNECTOR_WEIGHT = 33333
-const XDAI_CONNECTOR_WEIGHT = 100000
-const RETRY_EVERY = 1000
-
-const connectorWeights = new Map([
-  ['MAINNET_CONNECTOR_WEIGHT', MAINNET_CONNECTOR_WEIGHT],
-  ['RINKEBY_CONNECTOR_WEIGHT', RINKEBY_CONNECTOR_WEIGHT],
-  ['XDAI_CONNECTOR_WEIGHT', XDAI_CONNECTOR_WEIGHT],
-])
 const contractsCache = new Map()
 const tokenDecimals = new Map([
   [collateral.symbol, collateral.decimals],
   [bonded.symbol, bonded.decimals],
 ])
-
-function getConnectorWeight() {
-  const chainId = environment('CHAIN_ID')
-  return connectorWeights.get(
-    chainId === '1' ? 'MAINNET_CONNECTOR_WEIGHT' : chainId === '4' ? 'RINKEBY_CONNECTOR_WEIGHT' : 'XDAI_CONNECTOR_WEIGHT'
-  )
-}
 
 export function useContract(address, abi, signer = true) {
   const { ethersProvider } = useWalletAugmented()
@@ -59,6 +40,36 @@ export function useKnownContract(name, signer = true) {
 
 export function useTokenDecimals(symbol) {
   return tokenDecimals.get(symbol)
+}
+
+export function useConnectorWeight() {
+  const marketMakerContract = useKnownContract('MARKET_MAKER')
+  const [address] = getKnownContract('COLLATERAL_TOKEN')
+  
+  const [reserveRatio, setReserveRatio] = useState()
+  const [collateralToken, setCollateralToken] = useState()
+
+  const fetchCollateral = useCallback(async () => {
+    try {
+      if(!marketMakerContract) {
+        return null
+      }
+      const collateralToken = await marketMakerContract.getCollateralToken(address)
+  
+      setCollateralToken(collateralToken)
+  
+      return setReserveRatio(collateralToken[collateralToken.length - 1])
+    } catch (err) {
+      console.log(err)
+      throw new Error(err.message)
+    }
+  }, [address, marketMakerContract])
+
+  useEffect(() => {
+    fetchCollateral()
+  }, [fetchCollateral])
+
+  return [reserveRatio, collateralToken, marketMakerContract]
 }
 
 export function useTokenBalance(symbol, address = '') {
@@ -97,7 +108,7 @@ export function useTokenBalance(symbol, address = '') {
         setBalances([balance, spendableBalance])
       }
     })
-  }, [account, address, tokenContract])
+  }, [account, address, tokenContract, symbol, tokenManagerContract])
 
   useEffect(() => {
     // Always update the balance if updateBalance() has changed
@@ -135,7 +146,10 @@ export function useBondingCurvePrice(amount, forwards = true) {
 
   const [treasuryAddress] = getKnownContract('BONDING_CURVE_RESERVE')
   const [collateralTreasuryBalance] = useTokenBalance(collateral.symbol, treasuryAddress)
-  const connectorWeight = getConnectorWeight()
+  const [connectorWeight] = useConnectorWeight()
+
+  const RETRY_EVERY = 5000
+
   useEffect(() => {
     let cancelled = false
     let retryTimer


### PR DESCRIPTION
Substitute the `getConnectorWeight` function that wasn't dynamic and fetch the reserve ratio or connector weight from the Market Maker contract.

Solves #7 